### PR TITLE
Additional Features for Packwiz Install/Add

### DIFF
--- a/cmd/pw/main.go
+++ b/cmd/pw/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -35,7 +36,10 @@ var (
 	flagRefresh = flag.Bool("r", false, "refresh modpack after operations")
 
 	// import file
-	flagImport = flag.String("i", "", "import links from file")
+	flagImport  = flag.String("i", "", "import links from file")
+	flagMetaDir = flag.String("m", "", "meta directory (when using the import flag)")
+	flagConfirm = flag.Bool("y", false, "auto confirm (when using the import flag)")
+	flagSide    = flag.Bool("c", false, "client side mod (when using the import flag)")
 
 	args []string
 )
@@ -75,7 +79,7 @@ func main() {
 	}
 
 	if *flagBatch {
-		fmt.Println("[PackWrap] Batch mode\n")
+		fmt.Println("[PackWrap] Batch mode")
 		batchMode(*flagPackDir, args)
 	} else {
 		packwiz(*flagPackDir, args)
@@ -115,20 +119,43 @@ func importFromFile() {
 		if !strings.HasPrefix(line, "https://") {
 			continue
 		} else {
-			var modHost = ""
+			installArgs := []string{}
+			metaDir := "mods"
 
 			if strings.Contains(line, "modrinth.com/mod/") {
-				modHost = "mr"
-			}
-			if strings.Contains(line, "curseforge.com/minecraft/mc-mods/") {
-				modHost = "cf"
-			}
-			if modHost == "" {
+				installArgs = append(installArgs, "add", "mr")
+			} else if strings.Contains(line, "curseforge.com/minecraft") {
+				installArgs = append(installArgs, "add", "cf")
+			} else {
 				fmt.Println("[ERROR] unknown host", line)
 				continue
-			} else {
-				packwiz(*flagPackDir, []string{modHost, "install", line})
 			}
+			if strings.Contains(line, "curseforge.com/minecraft/texture-packs/") {
+				installArgs = append(installArgs, "--category", "texture-packs")
+				metaDir = "resourcepacks"
+			}
+			if *flagMetaDir != "" {
+				installArgs = append(installArgs, "--meta-dir", *flagMetaDir)
+				metaDir = *flagMetaDir
+			}
+			if *flagConfirm {
+				installArgs = append(installArgs, "-y")
+			}
+
+			installArgs = append(installArgs, line)
+			packwiz(*flagPackDir, installArgs)
+
+			if *flagSide {
+				m_file := filepath.Join(*flagPackDir, metaDir, fmt.Sprintf("%s.pw.toml", line))
+				f, err := ioutil.ReadFile(m_file)
+				if err != nil {
+					fmt.Println("Cannot read file: ", m_file)
+					continue
+				} else {
+					ioutil.WriteFile(m_file, []byte(strings.Replace(string(f), "\"side\": \"both\"", "\"side\": \"client\"", -1)), fs.FileMode(os.O_WRONLY))
+				}
+			}
+
 		}
 	}
 }

--- a/cmd/pw/main.go
+++ b/cmd/pw/main.go
@@ -154,7 +154,7 @@ func importFromFile() {
 					fmt.Println("Cannot read file: ", m_file)
 					continue
 				} else {
-					ioutil.WriteFile(m_file, []byte(strings.Replace(string(f), "side: \"both\"", "side: \"client\"", -1)), fs.FileMode(os.O_WRONLY))
+					ioutil.WriteFile(m_file, []byte(strings.Replace(string(f), "side = \"both\"", "side = \"client\"", -1)), fs.FileMode(os.O_WRONLY))
 				}
 			}
 

--- a/cmd/pw/main.go
+++ b/cmd/pw/main.go
@@ -154,7 +154,7 @@ func importFromFile() {
 					fmt.Println("Cannot read file: ", m_file)
 					continue
 				} else {
-					ioutil.WriteFile(m_file, []byte(strings.Replace(string(f), "\"side\": \"both\"", "\"side\": \"client\"", -1)), fs.FileMode(os.O_WRONLY))
+					ioutil.WriteFile(m_file, []byte(strings.Replace(string(f), "side: \"both\"", "side: \"client\"", -1)), fs.FileMode(os.O_WRONLY))
 				}
 			}
 

--- a/cmd/pw/main.go
+++ b/cmd/pw/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -147,7 +148,7 @@ func importFromFile() {
 			packwiz(*flagPackDir, installArgs)
 
 			if *flagSide {
-				m_file := filepath.Join(*flagPackDir, metaDir, fmt.Sprintf("%s.pw.toml", line))
+				m_file := filepath.Join(*flagPackDir, metaDir, fmt.Sprintf("%s.pw.toml", path.Base(line)))
 				f, err := ioutil.ReadFile(m_file)
 				if err != nil {
 					fmt.Println("Cannot read file: ", m_file)

--- a/cmd/pw/main.go
+++ b/cmd/pw/main.go
@@ -123,13 +123,13 @@ func importFromFile() {
 			metaDir := "mods"
 
 			if strings.Contains(line, "modrinth.com/mod/") {
-				installArgs = append(installArgs, "add", "mr")
+				installArgs = append(installArgs, "mr")
 			} else if strings.Contains(line, "curseforge.com/minecraft") {
-				installArgs = append(installArgs, "add", "cf")
+				installArgs = append(installArgs, "cf")
 			} else {
-				fmt.Println("[ERROR] unknown host", line)
-				continue
+				installArgs = append(installArgs, "url")
 			}
+			installArgs = append(installArgs, "add")
 			if strings.Contains(line, "curseforge.com/minecraft/texture-packs/") {
 				installArgs = append(installArgs, "--category", "texture-packs")
 				metaDir = "resourcepacks"
@@ -142,6 +142,7 @@ func importFromFile() {
 				installArgs = append(installArgs, "-y")
 			}
 
+			// Append the mod url
 			installArgs = append(installArgs, line)
 			packwiz(*flagPackDir, installArgs)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/appkins/packwiz-wrapper
+module github.com/Merith-TK/packwiz-wrapper
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Merith-TK/packwiz-wrapper
+module github.com/appkins/packwiz-wrapper
 
 go 1.18


### PR DESCRIPTION
- Supports cursed forge texture packs
- Supports adding client side mods
- Supports changing the meta folder for mod installation (mostly needed in texture/data packs with things like openloader)

I believe there are a few other things I'll try to document. One thing I'd like to add is url support that was introduced recently in packwiz. The batch feature would also make this especially nice.